### PR TITLE
chore: release v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0](https://github.com/cxreiff/ttysvr/compare/v0.1.4...v0.2.0) - 2024-08-16
+
+### Other
+- updated README for logo and homebrew
+- added dvd and tty logo savers
+- corrected homebrew tap name
+
 ## [0.1.4](https://github.com/cxreiff/ttysvr/compare/v0.1.3...v0.1.4) - 2024-08-15
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,7 +4651,7 @@ checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 
 [[package]]
 name = "ttysvr"
-version = "0.1.4"
+version = "0.2.0"
 dependencies = [
  "avian2d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttysvr"
 description = "Screensavers for your terminal."
-version = "0.1.4"
+version = "0.2.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["cxreiff <cooper@cxreiff.com>"]


### PR DESCRIPTION
## 🤖 New release
* `ttysvr`: 0.1.4 -> 0.2.0

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.0](https://github.com/cxreiff/ttysvr/compare/v0.1.4...v0.2.0) - 2024-08-16

### Other
- updated README for logo and homebrew
- added dvd and tty logo savers
- corrected homebrew tap name
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).