### PR TITLE
chore: release v0.2.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.2](https://github.com/cxreiff/ttysvr/compare/v0.2.1...v0.2.2) - 2024-10-03
+
+### Other
+
+- correction to README alt tags
+- example gifs
+- working maze screensaver
+- maze movement system
+- added maze generation
+- updated cargo-dist after homebrew contrib
+
 ## [0.2.1](https://github.com/cxreiff/ttysvr/compare/v0.2.0...v0.2.1) - 2024-08-17
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,7 +4651,7 @@ checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 
 [[package]]
 name = "ttysvr"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "avian2d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttysvr"
 description = "Screensavers for your terminal."
-version = "0.2.1"
+version = "0.2.2"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["cxreiff <cooper@cxreiff.com>"]

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Screensavers for your terminal. Start immediately or after a period of inactivity within a shell.
 
-![cube example](https://assets.cxreiff.com/github/ttysvr_logo.gif)![foxes](https://assets.cxreiff.com/github/ttysvr_bubbles.gif)![sponza test scene](https://assets.cxreiff.com/github/ttysvr_maze.gif)
+![bouncing logo](https://assets.cxreiff.com/github/ttysvr_logo.gif?)![bubbles](https://assets.cxreiff.com/github/ttysvr_bubbles.gif?)![maze](https://assets.cxreiff.com/github/ttysvr_maze.gif?)
 
 Uses [bevy_ratatui_render](https://github.com/cxreiff/bevy_ratatui_render), my
 bevy plugin that allows you to render a bevy application to the terminal using


### PR DESCRIPTION
## 🤖 New release
* `ttysvr`: 0.2.1 -> 0.2.2 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.2.2](https://github.com/cxreiff/ttysvr/compare/v0.2.1...v0.2.2) - 2024-10-03

### Other

- correction to README alt tags
- example gifs
- working maze screensaver
- maze movement system
- added maze generation
- updated cargo-dist after homebrew contrib
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).