### PR TITLE
chore: release v0.3.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.3](https://github.com/cxreiff/ttysvr/compare/v0.3.2...v0.3.3) - 2024-10-12
+
+### Other
+
+- upgraded versions, removed WindowPlugin fields
+
 ## [0.3.2](https://github.com/cxreiff/ttysvr/compare/v0.3.1...v0.3.2) - 2024-10-10
 
 ### Fixed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4651,7 +4651,7 @@ checksum = "5be21190ff5d38e8b4a2d3b6a3ae57f612cc39c96e83cedeaf7abc338a8bac4a"
 
 [[package]]
 name = "ttysvr"
-version = "0.3.2"
+version = "0.3.3"
 dependencies = [
  "avian2d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttysvr"
 description = "Screensavers for your terminal"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["cxreiff <cooper@cxreiff.com>"]


### PR DESCRIPTION
## 🤖 New release
* `ttysvr`: 0.3.2 -> 0.3.3 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.3](https://github.com/cxreiff/ttysvr/compare/v0.3.2...v0.3.3) - 2024-10-12

### Other

- upgraded versions, removed WindowPlugin fields
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).