### PR TITLE
chore: release v0.3.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.5](https://github.com/cxreiff/ttysvr/compare/v0.3.4...v0.3.5) - 2025-01-01
+
+### Other
+
+- bevy 0.15, bevy_ratatui_camera 0.8
+
 ## [0.3.4](https://github.com/cxreiff/ttysvr/compare/v0.3.3...v0.3.4) - 2024-11-27
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5084,7 +5084,7 @@ checksum = "2c591d83f69777866b9126b24c6dd9a18351f177e49d625920d19f989fd31cf8"
 
 [[package]]
 name = "ttysvr"
-version = "0.3.4"
+version = "0.3.5"
 dependencies = [
  "avian2d",
  "bevy",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "ttysvr"
 description = "Screensavers for your terminal"
-version = "0.3.4"
+version = "0.3.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 authors = ["cxreiff <cooper@cxreiff.com>"]


### PR DESCRIPTION
## 🤖 New release
* `ttysvr`: 0.3.4 -> 0.3.5 (✓ API compatible changes)

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.3.5](https://github.com/cxreiff/ttysvr/compare/v0.3.4...v0.3.5) - 2025-01-01

### Other

- bevy 0.15, bevy_ratatui_camera 0.8
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).